### PR TITLE
feat!: Migrate to new Client; Setup Testing Workflow with Voyage API Key; Rename `model_name` to `model`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  VOYAGE_API_KEY: ${{ secrets.VOYAGEAI_API_KEY }}
 
 jobs:
   run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 ]
 
 dependencies = [
-  "haystack-ai",
+  "haystack-ai==2.0.0b5",
   "typing_extensions",
   "numpy",
-  "voyageai==0.1.3"
+  "voyageai==0.1.7"
 ]
 
 [project.urls]
@@ -181,6 +181,7 @@ exclude_lines = [
 
 [tool.pytest.ini_options]
 minversion = "6.0"
+addopts = "-vv"
 markers = [
   "unit: unit tests",
   "integration: integration tests"

--- a/src/voyage_embedders/voyage_document_embedder.py
+++ b/src/voyage_embedders/voyage_document_embedder.py
@@ -1,14 +1,11 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-import voyageai
 from haystack.core.component import component
 from haystack.core.serialization import default_to_dict
 from haystack.dataclasses import Document
 from tqdm import tqdm
-from voyageai import get_embeddings
-
-MAX_BATCH_SIZE = 8
+from voyageai import Client
 
 
 @component
@@ -36,11 +33,12 @@ class VoyageDocumentEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "voyage-01",
+        model: str = "voyage-2",
         input_type: str = "document",
+        truncate: Optional[bool] = None,
         prefix: str = "",
         suffix: str = "",
-        batch_size: int = 8,
+        batch_size: int = 32,
         metadata_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
         progress_bar: bool = True,  # noqa
@@ -49,11 +47,21 @@ class VoyageDocumentEmbedder:
         Create a VoyageDocumentEmbedder component.
         :param api_key: The VoyageAI API key. It can be explicitly provided or automatically read from the
                         environment variable VOYAGE_API_KEY (recommended).
-        :param model_name: The name of the model to use. Defaults to "voyage-01".
+        :param model: The name of the model to use. Defaults to "voyage-2".
         For more details on the available models,
             see [Voyage Embeddings documentation](https://docs.voyageai.com/embeddings/).
-        :param input_type: Type of the input text. Defaults to `"document"`. This will set the prepend the text with,
-        "Represent the document for retrieval: ". Can be set to `None` for no prompt or `"query"` for the query prompt.
+        :param input_type: Type of the input text. This is used to prepend different prompts to the text.
+            - Defaults to `"document"`. This will prepend the text with, "Represent the document for retrieval: ".
+            - Can be set to `"query"`. For query, the prompt is "Represent the query for retrieving
+              supporting documents: ".
+            - Can be set to `None` for no prompt.
+        :param truncate: Whether to truncate the input texts to fit within the context length.
+            - If `True`, over-length input texts will be truncated to fit within the context length, before vectorized
+              by the embedding model.
+            - If False, an error will be raised if any given text exceeds the context length.
+            - Defaults to `None`, which will truncate the input text before sending it to the embedding model if it
+              slightly exceeds the context window length. If it significantly exceeds the context window length, an
+              error will be raised.
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
         :param batch_size: Number of Documents to encode at once.
@@ -62,28 +70,23 @@ class VoyageDocumentEmbedder:
         :param progress_bar: Whether to show a progress bar or not. Can be helpful to disable in production deployments
                              to keep the logs clean.
         """
-        # if the user does not provide the API key, check if it is set in the module client
-        api_key = api_key or voyageai.api_key
         if api_key is None:
             try:
                 api_key = os.environ["VOYAGE_API_KEY"]
             except KeyError as e:
-                msg = "VoyageDocumentEmbedder expects an VoyageAI API key. Set the VOYAGE_API_KEY environment variable (recommended) or pass it explicitly."  # noqa
+                msg = (
+                    "VoyageDocumentEmbedder expects an VoyageAI API key. "
+                    "Set the VOYAGE_API_KEY environment variable (recommended) or pass it explicitly."
+                )
                 raise ValueError(msg) from e
 
-        voyageai.api_key = api_key
-
-        self.model_name = model_name
+        self.client = Client(api_key=api_key)
+        self.model = model
         self.input_type = input_type
+        self.truncate = truncate
         self.prefix = prefix
         self.suffix = suffix
-
-        if batch_size <= MAX_BATCH_SIZE:
-            self.batch_size = batch_size
-        else:
-            err_msg = f"""VoyageDocumentEmbedder has a maximum batch size of {MAX_BATCH_SIZE}. Set the Set the batch_size to {MAX_BATCH_SIZE} or less."""  # noqa
-            raise ValueError(err_msg)
-
+        self.batch_size = batch_size
         self.progress_bar = progress_bar
         self.metadata_fields_to_embed = metadata_fields_to_embed or []
         self.embedding_separator = embedding_separator
@@ -95,8 +98,9 @@ class VoyageDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             input_type=self.input_type,
+            truncate=self.truncate,
             prefix=self.prefix,
             suffix=self.suffix,
             batch_size=self.batch_size,
@@ -124,24 +128,30 @@ class VoyageDocumentEmbedder:
             texts_to_embed.append(text_to_embed)
         return texts_to_embed
 
-    def _embed_batch(self, texts_to_embed: List[str], batch_size: int) -> List[List[float]]:
+    def _embed_batch(self, texts_to_embed: List[str], batch_size: int) -> Tuple[List[List[float]], Dict[str, Any]]:
         """
         Embed a list of texts in batches.
         """
 
         all_embeddings = []
+        meta: Dict[str, Any] = {}
+        meta["total_tokens"] = 0
         for i in tqdm(
             range(0, len(texts_to_embed), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
             batch = texts_to_embed[i : i + batch_size]
-            embeddings = get_embeddings(
-                list_of_text=batch, batch_size=batch_size, model=self.model_name, input_type=self.input_type
+            response = self.client.embed(
+                texts=batch,
+                model=self.model,
+                input_type=self.input_type,
+                truncation=self.truncate,
             )
-            all_embeddings.extend(embeddings)
+            all_embeddings.extend(response.embeddings)
+            meta["total_tokens"] += response.total_tokens
 
-        return all_embeddings
+        return all_embeddings, meta
 
-    @component.output_types(documents=List[Document])
+    @component.output_types(documents=List[Document], meta=Dict[str, Any])
     def run(self, documents: List[Document]):
         """
         Embed a list of Documents.
@@ -150,14 +160,17 @@ class VoyageDocumentEmbedder:
         :param documents: A list of Documents to embed.
         """
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
-            msg = "VoyageDocumentEmbedder expects a list of Documents as input.In case you want to embed a string, please use the VoyageTextEmbedder."  # noqa
+            msg = (
+                "VoyageDocumentEmbedder expects a list of Documents as input."
+                " In case you want to embed a string, please use the VoyageTextEmbedder."
+            )
             raise TypeError(msg)
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
 
-        embeddings = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
+        embeddings, meta = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
         for doc, emb in zip(documents, embeddings):
             doc.embedding = emb
 
-        return {"documents": documents}
+        return {"documents": documents, "meta": meta}

--- a/src/voyage_embedders/voyage_text_embedder.py
+++ b/src/voyage_embedders/voyage_text_embedder.py
@@ -1,10 +1,9 @@
 import os
 from typing import Any, Dict, List, Optional
 
-import voyageai
 from haystack.core.component import component
 from haystack.core.serialization import default_to_dict
-from voyageai import get_embedding
+from voyageai import Client
 
 
 @component
@@ -29,8 +28,9 @@ class VoyageTextEmbedder:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "voyage-01",
+        model: str = "voyage-2",
         input_type: str = "query",
+        truncate: Optional[bool] = None,
         prefix: str = "",
         suffix: str = "",
     ):
@@ -39,28 +39,40 @@ class VoyageTextEmbedder:
 
         :param api_key: The VoyageAI API key. It can be explicitly provided or automatically read from the
             environment variable VOYAGE_API_KEY (recommended).
-        :param model_name: The name of the Voyage model to use. Defaults to "voyage-01".
+        :param model: The name of the Voyage model to use. Defaults to "voyage-2".
         For more details on the available models,
             see [Voyage Embeddings documentation](https://docs.voyageai.com/embeddings/).
-        :param input_type: Type of the input text. Defaults to `"query"`. This will set the prepend the text with,
-        "Represent the query for retrieving supporting documents: ".  Can be set to `None` for no prompt or `"document"`
+        :param input_type: Type of the input text. This is used to prepend different prompts to the text.
+            - Defaults to `"query"`. This will prepend the text with, "Represent the query for retrieving
+              supporting documents: ".
+            - Can be set to `"document"`. For document, the prompt is "Represent the document for retrieval: ".
+            - Can be set to `None` for no prompt.
         for the document prompt.
+        :param truncate: Whether to truncate the input texts to fit within the context length.
+            - If `True`, over-length input texts will be truncated to fit within the context length, before vectorized
+              by the embedding model.
+            - If False, an error will be raised if any given text exceeds the context length.
+            - Defaults to `None`, which will truncate the input text before sending it to the embedding model if it
+              slightly exceeds the context window length. If it significantly exceeds the context window length, an
+              error will be raised.
         :param prefix: A string to add to the beginning of each text.
         :param suffix: A string to add to the end of each text.
         """
         # if the user does not provide the API key, check if it is set in the module client
-        api_key = api_key or voyageai.api_key
         if api_key is None:
             try:
                 api_key = os.environ["VOYAGE_API_KEY"]
             except KeyError as e:
-                msg = "VoyageTextEmbedder expects an VoyageAI API key. Set the VOYAGE_API_KEY environment variable (recommended) or pass it explicitly."  # noqa
+                msg = (
+                    "VoyageTextEmbedder expects an VoyageAI API key."
+                    " Set the VOYAGE_API_KEY environment variable (recommended) or pass it explicitly."
+                )
                 raise ValueError(msg) from e
 
-        voyageai.api_key = api_key
-
-        self.model_name = model_name
+        self.client = Client(api_key=api_key)
+        self.model = model
         self.input_type = input_type
+        self.truncate = truncate
         self.prefix = prefix
         self.suffix = suffix
 
@@ -71,18 +83,30 @@ class VoyageTextEmbedder:
         """
 
         return default_to_dict(
-            self, model_name=self.model_name, input_type=self.input_type, prefix=self.prefix, suffix=self.suffix
+            self,
+            model=self.model,
+            input_type=self.input_type,
+            truncate=self.truncate,
+            prefix=self.prefix,
+            suffix=self.suffix,
         )
 
-    @component.output_types(embedding=List[float])
+    @component.output_types(embedding=List[float], meta=Dict[str, Any])
     def run(self, text: str):
         """Embed a string."""
         if not isinstance(text, str):
-            msg = "VoyageTextEmbedder expects a string as an input.In case you want to embed a list of Documents, please use the VoyageDocumentEmbedder."  # noqa
+            msg = (
+                "VoyageTextEmbedder expects a string as an input. "
+                "In case you want to embed a list of Documents, please use the VoyageDocumentEmbedder."
+            )
             raise TypeError(msg)
 
         text_to_embed = self.prefix + text + self.suffix
 
-        embedding = get_embedding(text=text_to_embed, model=self.model_name, input_type=self.input_type)
+        response = self.client.embed(
+            texts=[text_to_embed], model=self.model, input_type=self.input_type, truncation=self.truncate
+        )
+        embedding = response.embeddings[0]
+        meta = {"total_tokens": response.total_tokens}
 
-        return {"embedding": embedding}
+        return {"embedding": embedding, "meta": meta}

--- a/tests/test_voyage_text_embedder.py
+++ b/tests/test_voyage_text_embedder.py
@@ -1,28 +1,20 @@
-from typing import List
-from unittest.mock import patch
+import os
 
-import numpy as np
 import pytest
-import voyageai
 
 from voyage_embedders.voyage_text_embedder import VoyageTextEmbedder
-
-
-def mock_voyageai_response(text: str, model: str = "voyage-01", **kwargs) -> List[float]:  # noqa
-    response = np.random.rand(1024).tolist()
-    return response
 
 
 class TestVoyageTextEmbedder:
     @pytest.mark.unit
     def test_init_default(self, monkeypatch):
-        voyageai.api_key = None
         monkeypatch.setenv("VOYAGE_API_KEY", "fake-api-key")
         embedder = VoyageTextEmbedder()
 
-        assert voyageai.api_key == "fake-api-key"
+        assert embedder.client.api_key == "fake-api-key"
         assert embedder.input_type == "query"
-        assert embedder.model_name == "voyage-01"
+        assert embedder.model == "voyage-2"
+        assert embedder.truncate is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""
 
@@ -30,20 +22,21 @@ class TestVoyageTextEmbedder:
     def test_init_with_parameters(self):
         embedder = VoyageTextEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
             input_type="document",
+            truncate=True,
             prefix="prefix",
             suffix="suffix",
         )
-        assert voyageai.api_key == "fake-api-key"
-        assert embedder.model_name == "model"
+        assert embedder.client.api_key == "fake-api-key"
+        assert embedder.model == "model"
+        assert embedder.truncate is True
         assert embedder.input_type == "document"
         assert embedder.prefix == "prefix"
         assert embedder.suffix == "suffix"
 
     @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
-        voyageai.api_key = None
         monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
         with pytest.raises(ValueError, match="VoyageTextEmbedder expects an VoyageAI API key"):
             VoyageTextEmbedder()
@@ -55,7 +48,8 @@ class TestVoyageTextEmbedder:
         assert data == {
             "type": "voyage_embedders.voyage_text_embedder.VoyageTextEmbedder",
             "init_parameters": {
-                "model_name": "voyage-01",
+                "model": "voyage-2",
+                "truncate": None,
                 "input_type": "query",
                 "prefix": "",
                 "suffix": "",
@@ -66,7 +60,8 @@ class TestVoyageTextEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         component = VoyageTextEmbedder(
             api_key="fake-api-key",
-            model_name="model",
+            model="model",
+            truncate=True,
             input_type="document",
             prefix="prefix",
             suffix="suffix",
@@ -75,29 +70,25 @@ class TestVoyageTextEmbedder:
         assert data == {
             "type": "voyage_embedders.voyage_text_embedder.VoyageTextEmbedder",
             "init_parameters": {
-                "model_name": "model",
+                "model": "model",
+                "truncate": True,
                 "input_type": "document",
                 "prefix": "prefix",
                 "suffix": "suffix",
             },
         }
 
-    @pytest.mark.unit
+    @pytest.mark.skipif(os.environ.get("VOYAGE_API_KEY", "") == "", reason="VOYAGE_API_KEY is not set")
+    @pytest.mark.integration
     def test_run(self):
-        model = "voyage-01-lite"
+        model = "voyage-lite-02-instruct"
 
-        with patch("voyage_embedders.voyage_text_embedder.get_embedding") as voyageai_embedding_patch:
-            voyageai_embedding_patch.side_effect = mock_voyageai_response
-
-            embedder = VoyageTextEmbedder(api_key="fake-api-key", model_name=model, prefix="prefix ", suffix=" suffix")
-            result = embedder.run(text="The food was delicious")
-
-            voyageai_embedding_patch.assert_called_once_with(
-                model=model, text="prefix The food was delicious suffix", input_type="query"
-            )
+        embedder = VoyageTextEmbedder(model=model, prefix="prefix ", suffix=" suffix")
+        result = embedder.run(text="The food was delicious")
 
         assert len(result["embedding"]) == 1024
         assert all(isinstance(x, float) for x in result["embedding"])
+        assert result["meta"]["total_tokens"] == 8, "Total tokens does not match"
 
     @pytest.mark.unit
     def test_run_wrong_input_format(self):


### PR DESCRIPTION
### Related Issues:

fixes: #18 
fixes: #19 
fixes: #20 

### Proposed Changes:

#### Migrate to `voyageai.Client`:

- Refactor code to use the new `voyageai.Client` instead of the deprecated `get_embedding` and `get_embeddings` method of the global namespace.
- Support for the new `truncate` parameter has been added.
- Default embedding model has been changed to "voyage-2" from the deprecated "voyage-01".
- The total number of tokens used are returned as part of the `"total_tokens"` in the metadata.
- Bump `voyageai` to `"0.17"` and pin `haystack-ai` to `"2.0.0b5"`

#### Setup Testing Workflow with Voyage API Key
- Added `VOYAGE_API_KEY` environment variable to testing workflow.

#### [Breaking Change] Rename `model_name` to `model`:
- Both `VoyageDocumentEmbedder` and `VoyageTextEmbedder` now accept the `model` parameter instead of `model_name`.