### PR TITLE
Bump minimum required python version to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Support longpaths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "voyage-embedders-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x component to embed strings and Documents using VoyageAI Embedding models.'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = ["Haystack", "VoyageAI"]
 authors = [{ name = "Ashwin Mathur", email = "" }]
@@ -20,7 +20,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: Implementation :: CPython",
@@ -59,7 +58,7 @@ test-examples = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]
 detached = true

--- a/src/haystack_integrations/components/embedders/voyage_embedders/__about__.py
+++ b/src/haystack_integrations/components/embedders/voyage_embedders/__about__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-present Ashwin Mathur <>
+# SPDX-FileCopyrightText: 2023-present - Ashwin Mathur
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.3.0"
+__version__ = "1.4.0"


### PR DESCRIPTION
### Proposed Changes:

- The `voyageai` python SDK requires python version 3.9 or above. Minimum requirements for this package have been bumped to python 3.9.
- The test workflows with python 3.8 have been removed.
- `pyproject.toml` has been updated to reflect the update minimum requirements.

